### PR TITLE
Added the option of using rgb and compression while maintaining original implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea
+.idea
 *.pt
 *.pth
 *.ckpt


### PR DESCRIPTION
Just a quality of life improvement for those who don't want to have to use the alpha channel of images. The compression uses the built in gzip implementation that python has and generally provides a ~50% compression ratio of text. With the compression as well as rgb, it should be possible to even encode the complete schizo neg in much smaller space.

The rgb implementation only uses the lsb of each channel, so it should still be unnoticeable. The way I figure out how the type of compression is by reading both the rgb and alpha for a signature, which is one of stealth_pnginfo, stealth_pngcomp, stealth_rgbinfo, and stealth_rgbcomp.
pnginfo is the original implementation, pngcomp is alpha + compression, rgbinfo is rgb without compression, and rgbcomp is rgb with compression.

I added two new settings for the mode and compression, as it can both encode and decode in all four modes.

I did also slightly re-organize the code so that all functions are above the normally run lines of code.