### PR TITLE
removed unused imports which prevented it from loading on gradio 3.28.1

### DIFF
--- a/scripts/stealth_pnginfo.py
+++ b/scripts/stealth_pnginfo.py
@@ -3,7 +3,7 @@ from modules.script_callbacks import ImageSaveParams
 import gradio as gr
 from modules import images
 from PIL import Image
-from gradio import media_data, processing_utils, utils
+from gradio import processing_utils
 import PIL
 import warnings
 import gzip


### PR DESCRIPTION
the import media_data was removed in gradio 3.28.1, however since that import was not being used, I just removed it. this was also true for the utils import, so I removed that one as well. removing them *doesn't* break support for earlier gradio versions, such as webui-ux